### PR TITLE
Update float to CGFloat for future proofing code (32-bit vs. 64-bit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ UAProgressView has sensible defaults to make setup a breeze.
 1. Add a custom view to your storyboard, xib or create a UAProgressView in code.
 2. Set the progress on your UAProgressView by calling `setProgress:`
 
-The progress should be a `float` between 0 and 1, but we will round to the closest if over/under.
+The progress should be a `CGFloat` between 0 and 1, but we will round to the closest if over/under.
 
 The default color used for UAProgressView is the view's `tintColor`, and it will travel up the superview tree as expected to set it.
 
@@ -142,13 +142,13 @@ self.progressView.didSelectBlock = ^(UAProgressView *progressView){
 You can set a block to be called whenever the progress is changed. This can be useful if the object updating the progress does not know about the central view.
 
 ```objc
-@property (nonatomic, copy) void (^progressChangedBlock)(UAProgressView *progressView, float progress);
+@property (nonatomic, copy) void (^progressChangedBlock)(UAProgressView *progressView, CGFloat progress);
 ```
 
 Example usage:
 
 ```objc
-self.progressView.progressChangedBlock = ^(UAProgressView *progressView, float progress){
+self.progressView.progressChangedBlock = ^(UAProgressView *progressView, CGFloat progress){
     [(UILabel *)progressView.centralView setText:[NSString stringWithFormat:@"%2.0f%%", progress * 100]];
 };
 ```

--- a/UAProgressView-Example/UAProgressView-Example/UAAdvancedExampleViewController.m
+++ b/UAProgressView-Example/UAProgressView-Example/UAAdvancedExampleViewController.m
@@ -18,7 +18,7 @@
 
 @property (nonatomic, assign) SystemSoundID horn;
 @property (nonatomic, assign) BOOL paused;
-@property (nonatomic, assign) float localProgress;
+@property (nonatomic, assign) CGFloat localProgress;
 
 @end
 
@@ -53,7 +53,7 @@
 		}
 	};
 	
-	self.progressView.progressChangedBlock = ^(UAProgressView *progressView, float progress){
+	self.progressView.progressChangedBlock = ^(UAProgressView *progressView, CGFloat progress){
 		[(UILabel *)progressView.centralView setText:[NSString stringWithFormat:@"%2.0f%%", progress * 100]];
 	};
 	

--- a/UAProgressView-Example/UAProgressView-Example/UABasicExampleViewController.m
+++ b/UAProgressView-Example/UAProgressView-Example/UABasicExampleViewController.m
@@ -19,7 +19,7 @@
 @property (nonatomic, weak) IBOutlet UAProgressView *progressView5;
 @property (nonatomic, weak) IBOutlet UAProgressView *progressView6;
 
-@property (nonatomic, assign) float localProgress;
+@property (nonatomic, assign) CGFloat localProgress;
 
 @end
 
@@ -55,7 +55,7 @@
 	label.userInteractionEnabled = NO; // Allows tap to pass through to the progress view.
 	self.progressView3.centralView = label;
 	
-	self.progressView3.progressChangedBlock = ^(UAProgressView *progressView, float progress) {
+	self.progressView3.progressChangedBlock = ^(UAProgressView *progressView, CGFloat progress) {
 		[(UILabel *)progressView.centralView setText:[NSString stringWithFormat:@"%2.0f%%", progress * 100]];
 	};
 }

--- a/UAProgressView.h
+++ b/UAProgressView.h
@@ -29,7 +29,7 @@
  *
  *  Example usage would be to update any central view labels
  */
-@property (nonatomic, copy) void (^progressChangedBlock)(UAProgressView *progressView, float progress);
+@property (nonatomic, copy) void (^progressChangedBlock)(UAProgressView *progressView, CGFloat progress);
 
 /**
  *  The view in the center of the progress view.
@@ -76,7 +76,7 @@
 /**
  *  Gets/sets the progress, from 0.0 to 1.0. Progress < 0 is set to 0.0, progress > 1 is set to 1.0
  */
-@property (nonatomic, assign) float progress;
+@property (nonatomic, assign) CGFloat progress;
 
 /**
  *  The duration over which to animate the progress set. Default is 0.3 seconds. animationDuration < 0 is ignored
@@ -92,6 +92,6 @@
  *  @param progress The new progress value.
  *  @param animated Specify YES to animate the change or NO if you do not want the change to be animated.
  */
-- (void)setProgress:(float)progress animated:(BOOL)animated;
+- (void)setProgress:(CGFloat)progress animated:(BOOL)animated;
 
 @end

--- a/UAProgressView.m
+++ b/UAProgressView.m
@@ -12,7 +12,7 @@ NSString * const UAProgressViewProgressAnimationKey = @"UAProgressViewProgressAn
 
 @interface UACircularProgressView : UIView
 
-- (void)updateProgress:(float)progress;
+- (void)updateProgress:(CGFloat)progress;
 - (CAShapeLayer *)shapeLayer;
 
 @end
@@ -141,7 +141,7 @@ NSString * const UAProgressViewProgressAnimationKey = @"UAProgressViewProgressAn
 
 #pragma mark - Progress Control
 
-- (void)setProgress:(float)progress animated:(BOOL)animated {
+- (void)setProgress:(CGFloat)progress animated:(BOOL)animated {
     
 	progress = MAX( MIN(progress, 1.0), 0.0); // keep it between 0 and 1
 	
@@ -166,7 +166,7 @@ NSString * const UAProgressViewProgressAnimationKey = @"UAProgressViewProgressAn
 	}
 }
 
-- (void)setProgress:(float)progress {
+- (void)setProgress:(CGFloat)progress {
 	[self setProgress:progress animated:NO];
 }
 
@@ -177,7 +177,7 @@ NSString * const UAProgressViewProgressAnimationKey = @"UAProgressViewProgressAn
     _animationDuration = animationDuration;
 }
 
-- (void)animateToProgress:(float)progress {
+- (void)animateToProgress:(CGFloat)progress {
     [self stopAnimation];
     
     // Add shape animation
@@ -363,11 +363,11 @@ NSString * const UAProgressViewProgressAnimationKey = @"UAProgressViewProgressAn
                                        clockwise:YES];
 }
 
-- (void)updateProgress:(float)progress {
+- (void)updateProgress:(CGFloat)progress {
     [self updatePath:progress];
 }
 
-- (void)updatePath:(float)progress {
+- (void)updatePath:(CGFloat)progress {
 	[CATransaction begin];
 	[CATransaction setValue:(id)kCFBooleanTrue forKey:kCATransactionDisableActions];
 	self.shapeLayer.strokeEnd = progress;


### PR DESCRIPTION
Apple recommends changing `float` to `CGFloat` with the introduction of the 64-bit CPU, as the `float` get's typedef'ed depending on the CPU type.

Apple recommends using the `CGFloat` "type" consistently in the documentation since the introduction of the 64-bit CPUs, and since UAProgressView currently uses `float` for "progress," many developers that have started using `CGFloat` (as well as NSInteger) in their applications will no longer be consistent.

https://developer.apple.com/library/ios/documentation/General/Conceptual/CocoaTouch64BitGuide/ConvertingYourAppto64-Bit/ConvertingYourAppto64-Bit.html

Since this will be an interface change, a new pod should be rolled out as well with the update.
