### PR TITLE
Fix progress flashing in setprogress:animated:YES.

### DIFF
--- a/UAProgressView.m
+++ b/UAProgressView.m
@@ -182,6 +182,8 @@ NSString * const UAProgressViewProgressAnimationKey = @"UAProgressViewProgressAn
     
     // Add shape animation
     CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
+    animation.removedOnCompletion = NO;
+    animation.fillMode = kCAFillModeForwards;
     animation.duration = self.animationDuration;
     animation.fromValue = @(self.progress);
     animation.toValue = @(progress);


### PR DESCRIPTION
fixes #6: progress flashing in setprogress:animated:YES.

Animation did reset on to initial value on finish and created a blink.
See the discussion about this:
http://stackoverflow.com/questions/6059054/cabasicanimation-resets-to-initial-value-after-animation-completes