### PR TITLE
Add Long Press Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,32 @@ The duration over which to animate the progress set. Default is 0.3 seconds. ani
 The `animationDuration` variable is only used when calling `setProgress:animated:` with `YES`.
 
 
+#### Long Press Gesture
+
+This is the gesture that is created on the progress view to handle selection and (optionally) the long press.  You can use this to customize the minimum duration required to invoke the selection gesture.
+
+```objc
+@property (nonatomic, strong) UILongPressGestureRecognizer *gestureRecognizer;
+```
+
+
+#### Long Press Duration
+
+Specify an optional long press duration that will fire the `didLongPressBlock` when reached.  Must be > 0.0.  Default is 0.0 (disabled).
+
+```objc
+@property (nonatomic, assign) CGFloat longPressDuration;
+```
+
+
+#### Long Press Cancelling Selection
+
+By default, the long press action will also trigger the selection action.  You can disable this functionality with this property.  Default is NO.
+
+```objc
+@property (nonatomic, assign) BOOL longPressCancelsSelect;
+```
+
 
 ### Event Blocks
 
@@ -136,6 +162,21 @@ self.progressView.didSelectBlock = ^(UAProgressView *progressView){
 };
 ```
 
+##### On Long Press
+
+You can set a block to be called when there was an optional long press on the progress view.  The long press is triggered when the `longPressDuration` is reached.
+
+```objc
+@property (nonatomic, copy) void (^didLongPressBlock)(UAProgressView *progressView);
+```
+
+Example usage:
+
+```objc
+self.progressView. didLongPressBlock = ^(UAProgressView *progressView){
+    // Do something after long pressing the progress view
+};
+```
 
 ##### On Progress Change
 

--- a/UAProgressView-Example/UAProgressView-Example/UAAdvancedExampleViewController.m
+++ b/UAProgressView-Example/UAProgressView-Example/UAAdvancedExampleViewController.m
@@ -34,6 +34,8 @@
 	self.progressView.borderWidth = 2.0;
 	self.progressView.lineWidth = 2.0;
 	self.progressView.fillOnTouch = YES;
+    self.progressView.longPressDuration = 1.0;
+    self.progressView.longPressCancelsSelect = YES;
 	
 	UILabel *textLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 60.0, 32.0)];
 	textLabel.font = [UIFont fontWithName:@"HelveticaNeue-UltraLight" size:32];
@@ -65,6 +67,11 @@
 		AudioServicesPlaySystemSound(_horn);
 		_paused = !_paused;
 	};
+    
+    self.progressView.didLongPressBlock = ^(UAProgressView *progressView) {
+        _paused = YES;
+        _localProgress = progressView.progress = 0.0;
+    };
 	
 	self.progressView.progress = 0;
 	

--- a/UAProgressView.h
+++ b/UAProgressView.h
@@ -107,6 +107,12 @@
 - (void)addFill;
 
 /**
+ *  The long press gesture that is used to recognize single taps and long presses on the central
+ *  view.
+ */
+@property (nonatomic, strong) UILongPressGestureRecognizer *gestureRecognizer;
+
+/**
  *  Specify an optional long press duration that will fire the didLongPressBlock when reached.
  *  Must be > 0.0.
  *

--- a/UAProgressView.h
+++ b/UAProgressView.h
@@ -115,7 +115,7 @@
 @property (nonatomic, assign) CGFloat longPressDuration;
 
 /**
- * Cancels the selection when the long press gesture is reached.
+ * Cancels the selection when the long press duration is reached.
  *
  * Default is NO.
  */

--- a/UAProgressView.h
+++ b/UAProgressView.h
@@ -106,4 +106,26 @@
  */
 - (void)addFill;
 
+/**
+ *  Specify an optional long press duration that will fire the didLongPressBlock when reached.
+ *  Must be > 0.0.
+ *
+ *  Default is 0.0 (disabled).
+ */
+@property (nonatomic, assign) CGFloat longPressDuration;
+
+/**
+ * Cancels the selection when the long press gesture is reached.
+ *
+ * Default is NO.
+ */
+@property (nonatomic, assign) BOOL longPressCancelsSelect;
+
+/**
+ *  Called on when the longPressDuration has been reached.
+ *
+ *  Example usage would be to reset the progress.
+ */
+@property (nonatomic, copy) void (^didLongPressBlock)(UAProgressView *progressView);
+
 @end

--- a/UAProgressView.m
+++ b/UAProgressView.m
@@ -23,7 +23,6 @@ NSString * const UAProgressViewProgressAnimationKey = @"UAProgressViewProgressAn
 @property (nonatomic, assign) int valueLabelProgressPercentDifference;
 @property (nonatomic, strong) NSTimer *valueLabelUpdateTimer;
 @property (nonatomic, strong) NSTimer *longPressTimer;
-@property (nonatomic, strong) UILongPressGestureRecognizer *gestureRecognizer;
 
 @end
 


### PR DESCRIPTION
After making Issue #15 about a year ago, I finally got around to implementing the option to adding a Long Press action.

The way it works is when you specify a long press duration, the long press action will be called after the duration is reached.  Optionally, you can have it cancel the regular selection action as well (this does not happen by default).

My test environment is Xcode 8.2.1 and I'm using an iOS 10 simulator.  My implementation only adds an NSTimer and a few properties, so there should be no code here that would break for older platforms.  I also implemented the feature in the "advanced" example.

If you do decide to approve this pull, can you bump the version number and also make the changes in the pod project?